### PR TITLE
DOD-3555 Update AWS Docs links for attributes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,16 @@ pipeline {
         black --check *.py
         bandit query_ec2_metadata.py
 
+        # smoke test
+        pip install .
+        which ec2-metadata
+
+        METADATA_REGION=\$(ec2-metadata placement/region)
+        if [ "\$METADATA_REGION" != "eu-west-2" ]; then
+            echo "ec2-metadata returned unexpected region: \$METADATA_REGION"
+            exit 1
+        fi
+
         deactivate""")
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ pipeline {
 	    mypy --install-types --non-interactive --ignore-missing-imports query_ec2_metadata.py
         black --check *.py
         bandit query_ec2_metadata.py
-	    safety check
 
         deactivate""")
       }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It uses IMDSv2. Session credentials are NOT available using this.
 
 ## Installation
 
-Available on Pypi as [query-ec2-metadata](https://pypi.org/project/query-ec2-metadata/) 
+Available on Pypi as [query-ec2-metadata](https://pypi.org/project/query-ec2-metadata/)
 
   `pip install query-ec2-metadata`
 
@@ -19,7 +19,7 @@ Usage:
 
   This returns an attribute from the instance metadata.
 
-  The KEY can be any of the data values from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
+  The KEY can be any of the data values from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
 ### instance-identity
 
@@ -35,19 +35,19 @@ Usage:
 Usage:
   `instance-tag KEY`
 
-  This return the instance tag with the specified key. 
-  
+  This return the instance tag with the specified key.
+
   This will use the metadata endpoint if tags in metadata is enabled. If it's not enabled, will try and use the EC2 API.
 
 
 ## Python module
 
 ### instance_identity_document() -> dict[str, str]:
-    
+
 This returns the identity document for the instance.
 
 ### instance_identity(key: str) -> str:
-   
+
 This returns an attribute from the instance identity document.
 
 The key can be any of the data values from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
@@ -56,12 +56,12 @@ The key can be any of the data values from https://docs.aws.amazon.com/AWSEC2/la
 
 This returns an attribute from the instance metadata.
 
-The key can be any of the data values from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html
+The key can be any of the data values from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
 ### instance_tags() -> dict[str, str]:
-    
-This returns all the tags on the instance. 
+
+This returns all the tags on the instance.
 
 ### instance_tag(key: str) -> str:
-    
+
 This returns the instance tag value for the specified key.

--- a/query_ec2_metadata.py
+++ b/query_ec2_metadata.py
@@ -7,8 +7,7 @@ from typing import Dict
 
 import requests
 from requests import HTTPError
-from requests.packages.urllib3 import Retry
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter, Retry
 
 
 def instance_tags_ec2() -> Dict[str, str]:

--- a/tests/test_ec2_metadata.py
+++ b/tests/test_ec2_metadata.py
@@ -5,7 +5,7 @@ import boto3
 import httpretty
 import pytest
 import requests
-from moto import mock_ec2
+from moto import mock_aws
 from requests import HTTPError
 
 from query_ec2_metadata import (
@@ -258,7 +258,7 @@ def test_instance_tags_via_ec2(
     instance_tag.assert_not_called()
 
 
-@mock_ec2
+@mock_aws
 @mock.patch("query_ec2_metadata.ec2_metadata")
 def test_instance_tags_ec2(ec2_metadata):
     instance_id = "i-0278698c48372092d"


### PR DESCRIPTION
Fixes broken attribute links that would redirect to a generic
[AWS EC2 page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html)
